### PR TITLE
Remove ascii-progress dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "unpack": "./dist/index.js"
   },
   "dependencies": {
-    "ascii-progress": "^1.0.5",
     "chalk": "^2.3.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
@@ -35,9 +34,9 @@
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
+    "@types/minimist": "^1.2.0",
     "@types/mkdirp": "^0.5.2",
     "@types/source-map": "^0.5.7",
-    "@types/minimist": "^1.2.0",
     "ts-node": "^5.0.1",
     "typescript": "^2.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "source-map-unpack",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Unpack 🛍  your JS source maps 🗺  to original files and folders.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk'
 import { dirname, join, isAbsolute } from 'path'
 import * as mkdirp from 'mkdirp'
 import { SourceMapConsumer } from 'source-map'
-import * as ProgressBar from 'ascii-progress'
 import * as minimist from 'minimist'
 
 const argv = minimist(process.argv.slice(2))
@@ -42,18 +41,12 @@ try {
     SourceMapConsumer.with(mapFile, null, (consumer: SourceMapConsumer) => {
         console.log(chalk.green(`Unpacking 🛍  your source maps 🗺`))
         const sources = (consumer as any).sources
-        var bar = new ProgressBar({
-            schema: ' [:filled.green:blank] :current/:total :percent :elapseds :etas',
-            total: sources.length
-        })
-
         sources.forEach((source: string) => {
             const WEBPACK_SUBSTRING_INDEX = 11
             const content = consumer.sourceContentFor(source)
             const filePath = `${process.cwd()}/${projectNameInput}/${source.substring(WEBPACK_SUBSTRING_INDEX)}`
             mkdirp.sync(dirname(filePath))
             fs.writeFileSync(filePath, content)
-            bar.tick()
         })
         console.log(chalk.green('🎉  All done! Enjoy exploring your code 💻'))
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,25 +34,9 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi.js@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ansi.js/-/ansi.js-0.0.5.tgz#e3e9e45eb6977ba0eeeeed11677d12144675348c"
-  dependencies:
-    on-new-line "0.0.1"
-
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-
-ascii-progress@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/ascii-progress/-/ascii-progress-1.0.5.tgz#9610aa127ab794af561e893613c36c906f78d9ee"
-  dependencies:
-    ansi.js "0.0.5"
-    end-with "^1.0.2"
-    get-cursor-position "1.0.3"
-    on-new-line "1.0.0"
-    start-with "^1.0.2"
 
 chalk@*, chalk@^2.3.0, chalk@^2.3.2:
   version "2.3.2"
@@ -76,17 +60,9 @@ diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
-end-with@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/end-with/-/end-with-1.0.2.tgz#a432755ab4f51e7fc74f3a719c6b81df5d668bdc"
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-get-cursor-position@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/get-cursor-position/-/get-cursor-position-1.0.3.tgz#0e41d60343b705836a528d69a5e099e2c5108d63"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -110,14 +86,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-on-new-line@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/on-new-line/-/on-new-line-0.0.1.tgz#99339cb06dcfe3e78d6964a2ef2af374a145f8fb"
-
-on-new-line@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/on-new-line/-/on-new-line-1.0.0.tgz#8585bc2866c8c0e192e410a6d63bdd1722148ae7"
-
 source-map-support@^0.5.3:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
@@ -131,10 +99,6 @@ source-map@*, source-map@^0.7.2:
 source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-start-with@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/start-with/-/start-with-1.0.2.tgz#a069a5f46a95fca7f0874f85a28f653d0095c267"
 
 supports-color@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
ascii-progress had a dependency on a module that won't compile in current node versions and hasn't been maintained in 4 years