### PR TITLE
Refactor npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "source-map": "^0.7.2"
   },
   "scripts": {
-    "prepublish": "npm run build",
-    "build": "./node_modules/.bin/tsc",
-    "start": "./node_modules/.bin/ts-node -- ./src/index.ts"
+    "prepublish": "yarn build",
+    "build": "tsc",
+    "start": "ts-node src/index.ts"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
The PR refactors the npm scripts in package.json to use a different pattern for running package binaries.

### Comparison

#### 533b54c (master)

> ./\<path\>/\<binary\> -- \<arguments\>

- The double dash used in the `start` command is misused. It signals to the preceding command to stop parsing command-line arguments. In this case, either Yarn strips it before running `ts-node` or `ts-node` simply ignores it.

#### 4de7673

> \<binary\> \<arguments\>

- The location of the binary (or, more generally, *what to run*) is determined by the process running the script through module resolution. Running package binaries this way respects any binary links that may have been added by a package (via the `bin` property) while also maintaining the Node.js module abstraction.
- Yarn passes along various Node.js-related information relating to its process to any binaries it calls like this.