### PR TITLE
Add `string` type assertion to `content`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ try {
         const sources = (consumer as any).sources
         sources.forEach((source: string) => {
             const WEBPACK_SUBSTRING_INDEX = 11
-            const content = consumer.sourceContentFor(source)
+            const content = consumer.sourceContentFor(source) as string
             const filePath = `${process.cwd()}/${projectNameInput}/${source.substring(WEBPACK_SUBSTRING_INDEX)}`
             mkdirp.sync(dirname(filePath))
             fs.writeFileSync(filePath, content)


### PR DESCRIPTION
Type assertions generally don't make sense to use but, in this case, it appears that the type declaration of `sourceContentFor()` doesn't reflect [its nuanced behavior](https://github.com/mozilla/source-map/blob/master/README.md#sourcemapconsumerprototypesourcecontentforsource-returnnullonmissing). Because of the way `sourceContentFor()` is called, `content` will only ever be of type `string`.

Fixes #5