### PR TITLE
Change `prepublish` to `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "source-map": "^0.7.2"
   },
   "scripts": {
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "build": "tsc",
     "start": "ts-node src/index.ts"
   },


### PR DESCRIPTION
### Comparison

#### 0f7f007 (master)

```console
$ rm -rf node_modules/ dist/
$ time yarn install
yarn install v1.22.10
[…]

real    0m1.901s
user    0m2.507s
sys     0m0.612s
```

#### 4e0a215

```console
$ rm -rf node_modules/ dist/
$ time yarn install
yarn install v1.22.10
[…]

real    0m0.636s
user    0m0.415s
sys     0m0.491s
```

- `real    0m1.901s` (before)
- `real    0m0.636s` (now)

Installations are ~200% faster.

Fixes #18