### PR TITLE
Use `--build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "prepublish": "yarn build",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "start": "ts-node src/index.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build": "tsc",
+    "build": "tsc --build",
     "start": "ts-node src/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
### Comparison

#### 0f7f007 (master)

```console
$ rm -rf dist/
```

```console
$ time yarn build
yarn run v1.22.10
[…]

real    0m1.201s
user    0m1.737s
sys     0m0.159s
```

```console
$ time yarn build
yarn run v1.22.10
[…]

real    0m1.226s
user    0m1.775s
sys     0m0.163s
```

#### 06c3a1e

```console
$ rm -rf dist/
```

```console
$ time yarn build
yarn run v1.22.10
[…]

real    0m1.203s
user    0m1.739s
sys     0m0.158s
```
```console
$ time yarn build
yarn run v1.22.10
[…]

real    0m0.425s
user    0m0.320s
sys     0m0.091s
```

- `real    0m1.226s` (before)
- `real    0m0.425s` (now)

Subsequent builds are now ~200% faster.