### PR TITLE
Update source-map to fix compatibility with Node 18 (closes #32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chalk": "4.1.2",
     "minimist": "1.2.6",
     "mkdirp": "1.0.4",
-    "source-map": "0.7.3"
+    "source-map": "^0.7.4"
   },
   "scripts": {
     "prepublishOnly": "yarn build",
@@ -41,8 +41,8 @@
     "@types/mkdirp": "1.0.2",
     "@types/node": "17.0.36",
     "@types/source-map": "0.5.7",
-    "ts-node": "10.8.0",
     "prettier": "2.6.2",
+    "ts-node": "10.8.0",
     "typescript": "4.7.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
-import mkdirp from 'mkdirp';
+import * as mkdirp from 'mkdirp';
 import * as chalk from 'chalk';
 import * as minimist from 'minimist';
 import { SourceMapConsumer } from 'source-map';

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,10 +155,10 @@ source-map@*:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.2.tgz#115c3e891aaa9a484869fd2b89391a225feba344"
 
-source-map@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
@pavloko ,

This solves the following error when attempting to run under Node 18:

```
/home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/read-wasm.js:8
      throw new Error("You must provide the URL of lib/mappings.wasm by calling " +
            ^
Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
    at readWasm (/home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/read-wasm.js:8:13)
    at wasm (/home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/wasm.js:25:16)
    at /home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/source-map-consumer.js:264:14
```

Had to adjust an import as well since it was failing with:

```
/home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/source-map-consumer.js:70
      return await f(consumer);
                   ^
TypeError: Cannot read properties of undefined (reading 'sync')
    at /home/elian/Projects/OpenSource/source-map-unpack/src/index.ts:59:14
    at Array.forEach (<anonymous>)
    at /home/elian/Projects/OpenSource/source-map-unpack/src/index.ts:53:13
    at Function.with (/home/elian/Projects/OpenSource/source-map-unpack/node_modules/source-map/lib/source-map-consumer.js:70:20)
```
